### PR TITLE
Change of widget name: from Autocomplete to AutoComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use it, there is a set a scripts that are available after the usual *npm inst
 
 A new widget library is defined [`LightWidgetLib`](./src/atplugins/lightWidgets/LightWidgetLib.js) which contains the following widgets:
  - `TextInput`: a text input based on the `html` textinput widget. It allows to register a listener to the `change` event in a cross-browser way.
- - `Autocomplete`: an autocomplete which allows to specify a resources handler and a template to print the list of suggestions, just like the standard `aria` autocomplete. [Configuration bean](./src/atplugins/lightWidgets/autocomplete/AutocompleteCfgBeans.js).
+ - `AutoComplete`: an autocomplete which allows to specify a resources handler and a template to print the list of suggestions, just like the standard `aria` autocomplete. [Configuration bean](./src/atplugins/lightWidgets/autocomplete/AutocompleteCfgBeans.js).
  - `DateField`: an input which is able to interpret the input string and turn it into a date (see [here](http://www.ariatemplates.com/usermanual/latest/datefield) for more information on the interpreter). [Configuration bean](./src/atplugins/lightWidgets/datefield/DateFieldCfgBeans.js).
  - `Calendar`: a simple calendar, very similar to the `aria` calendar, but skinless and simpler. [Configuration bean](./src/atplugins/lightWidgets/calendar/CalendarCfgBeans.js).
  - `DatePicker`: it combines the light `DateField` and `Calendar` widgets. [Configuration bean](./src/atplugins/lightWidgets/datepicker/DatePickerCfgBeans.js).

--- a/sample/app/SampleTemplate.tpl
+++ b/sample/app/SampleTemplate.tpl
@@ -66,7 +66,7 @@
 
 		<h2>Autocomplete</h2>
 		<div>
-			{@light:Autocomplete {
+			{@light:AutoComplete {
 				id : "ac",
 				resourcesHandler : "app.SampleResourcesHandler",
 				suggestionsTemplate: "atplugins.lightWidgets.autocomplete.AutocompleteTemplate",

--- a/src/atplugins/lightWidgets/LightWidgetLib.js
+++ b/src/atplugins/lightWidgets/LightWidgetLib.js
@@ -27,7 +27,7 @@
                 "TextInput" : basePath + "textinput.TextInputWithOnChange",
                 "DatePicker" : basePath + "datepicker.DatePicker",
                 "DateField" : basePath + "datefield.DateField",
-                "Autocomplete" : basePath + "autocomplete.Autocomplete",
+                "AutoComplete" : basePath + "autocomplete.Autocomplete",
                 "Calendar" : basePath + "calendar.Calendar"
             }
         }

--- a/test/atplugins/lightWidgets/autocomplete/AutocompleteTestBaseTpl.tpl
+++ b/test/atplugins/lightWidgets/autocomplete/AutocompleteTestBaseTpl.tpl
@@ -23,7 +23,7 @@
 
     {macro main()}
 
-      {@light:Autocomplete {
+      {@light:AutoComplete {
           id: "autocomplete",
           suggestionsTemplate: "atplugins.lightWidgets.autocomplete.AutocompleteTemplate",
           bind: {

--- a/test/atplugins/lightWidgets/autocomplete/AutocompleteTestCaseTpl.tpl
+++ b/test/atplugins/lightWidgets/autocomplete/AutocompleteTestCaseTpl.tpl
@@ -24,7 +24,7 @@
     {macro main()}
       <div id="container" style="width: 200px;height: 200px;">
 
-        {@light:Autocomplete {
+        {@light:AutoComplete {
             id: "always",
             suggestionsTemplate: "atplugins.lightWidgets.autocomplete.AutocompleteTemplate",
             bind: {
@@ -42,7 +42,7 @@
             preselect: "always"
         } /}
 
-        {@light:Autocomplete {
+        {@light:AutoComplete {
             id: "none",
             suggestionsTemplate: "atplugins.lightWidgets.autocomplete.AutocompleteTemplate",
             bind: {
@@ -60,7 +60,7 @@
             preselect: "none"
         } /}
 
-        {@light:Autocomplete {
+        {@light:AutoComplete {
             id: "no_preselect",
             suggestionsTemplate: "atplugins.lightWidgets.autocomplete.AutocompleteTemplate",
             bind: {


### PR DESCRIPTION
The name of the widget has been changed to AutoComplete to match the name it has in the aria library.
